### PR TITLE
Register mousemove listener for single execution

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,10 +60,9 @@ var PAGE_LAZYLOAD; // GLOBAL page lazyload instance
 	const initializeMouseEvents = () => {
 		console.log("Mouse detected. Initializing mouse events.");
 		listenToMouseover();
-		$window.off("mousemove", initializeMouseEvents);
 	};
 
 	$(function() {
-		$window.on("mousemove", initializeMouseEvents);
+		$window.one("mousemove", initializeMouseEvents);
 	});
 })();


### PR DESCRIPTION
Use jquery .one instead of .on to avoid the call of .off to deregister the listener